### PR TITLE
Add header version comparison

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: python
 python:
     - "3.5"
 
-script: "python check_for_updates.py"
+script: "python check_for_updates.py -d"

--- a/check_for_updates.py
+++ b/check_for_updates.py
@@ -1,61 +1,109 @@
 # Script is tested on OS X 10.12
 # YOUR MILEAGE MAY VARY
 
-from urllib.request import urlopen
+import urllib.request
+import zipfile
+import shutil
+import sys
 import re
 
-cube_urls = {
-    "f0": "http://www.st.com/en/embedded-software/stm32cubef0.html",
-    "f1": "http://www.st.com/en/embedded-software/stm32cubef1.html",
-    "f2": "http://www.st.com/en/embedded-software/stm32cubef2.html",
-    "f3": "http://www.st.com/en/embedded-software/stm32cubef3.html",
-    "f4": "http://www.st.com/en/embedded-software/stm32cubef4.html",
-    "f7": "http://www.st.com/en/embedded-software/stm32cubef7.html",
-    "l0": "http://www.st.com/en/embedded-software/stm32cubel0.html",
-    "l1": "http://www.st.com/en/embedded-software/stm32cubel1.html",
-    "l4": "http://www.st.com/en/embedded-software/stm32cubel4.html",
-}
-cube_current_versions = {}
-cube_new_versions = {}
-cube_dl_urls = {}
+stm32_families = [
+    "f0", "f1", "f2",
+    "f3", "f4", "f7",
+    "l0", "l1", "l4"
+]
 
+def get_local_cube_version(readme, family):
+    regex = "\(Cube{} v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)\)".format(family.upper())
+    match = re.search(regex, readme)
+    return match.group("version") if match else None
+
+def get_header_version(release_notes):
+    vmatch = re.search("\">V(?P<version>[0-9]+\.[0-9]+\.[0-9]+)", release_notes)
+    return vmatch.group("version") if vmatch else None
+
+def get_remote_cube_version(html):
+    vmatch = re.search("    (?P<version>[0-9]+\.[0-9]+\.[0-9]+)", html)
+    return vmatch.group("version") if vmatch else None
+
+def get_remote_zip_url(html):
+    dlmatch = re.search("data-download-path=\"(?P<dlurl>/content/ccc/resource/.*?\.zip)\"", html)
+    return "http://www.st.com" + dlmatch.group("dlurl") if dlmatch else None
+
+
+cube_local_version = {}
+header_local_version = {}
 # parse the versions directly from the README
 with open("README.md", "r") as readme:
     content = readme.read()
-    for family in cube_urls:
-        regex = "\(Cube{} v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)\)".format(family.upper())
-        match = re.search(regex, content)
-        if match:
-            cube_current_versions[family] = match.group('version')
-        else:
-            print("No version match for", family)
+    for family in stm32_families:
+        # extract local cube version from local readme
+        cube_local_version[family] = get_local_cube_version(content, family)
+        if not cube_local_version[family]:
+            print("No version match in local Readme for", family)
+            exit(1)
+        # extract local header version from local release notes
+        with open("stm32{}xx/Release_Notes.html".format(family), "r", errors="replace") as html:
+            header_local_version[family] = get_header_version(html.read())
+        if not header_local_version[family]:
+            print("No version match in local release notes for", family)
             exit(1)
 
+cube_remote_version = {}
+cube_dl_url = {}
+cube_furl = "http://www.st.com/en/embedded-software/stm32cube{}.html"
 # parse the versions and download links from ST's website
-for family, url in cube_urls.items():
-    response = urlopen(url)
-    html = response.read().decode('utf-8')
-
-    dlmatch = re.search("data-download-path=\"(?P<dlurl>/content/ccc/resource/.*?\.zip)\"", html)
-    if dlmatch:
-        cube_dl_urls[family] = "http://www.st.com" + dlmatch.group('dlurl')
-    else:
-        print("No download link for", family)
-        exit(1)
-
-    vmatch = re.search("    (?P<version>[0-9]+\.[0-9]+\.[0-9]+)", html)
-    if dlmatch:
-        cube_new_versions[family] = vmatch.group('version')
-    else:
-        print("No version match in html for", family)
-        exit(1)
+for family in stm32_families:
+    with urllib.request.urlopen(cube_furl.format(family)) as response:
+        html = response.read().decode("utf-8")
+        # extract remote cube version from website
+        cube_remote_version[family] = get_remote_cube_version(html)
+        if not cube_remote_version[family]:
+            print("No version match in remote html for", family)
+            exit(1)
+        # extract cube download link from website
+        cube_dl_url[family] = get_remote_zip_url(html)
+        if not cube_dl_url[family]:
+            print("No zip download link for", family)
+            exit(1)
 
 # compare all versions and print a status page
+check_header_version = [f for f in stm32_families if cube_local_version[f] != cube_remote_version[f]]
+header_remote_version = {}
+# compare local and remote header versions
+for family in check_header_version:
+    # download cmsis pack into zip file
+    dl_file = "{}.zip".format(family)
+    if "-d" in sys.argv:
+        print("Downloading '{}.zip' ...".format(family))
+        with urllib.request.urlopen(cube_dl_url[family]) as response, \
+                              open(dl_file, "wb") as out_file:
+            shutil.copyfileobj(response, out_file)
+    # extract the remote header version from the zip file
+    with zipfile.ZipFile(dl_file, "r") as zip_ref:
+        base_name = zip_ref.namelist()[0].split("/")[0]
+        release_note_path = "{}/Drivers/CMSIS/Device/ST/STM32{}xx/Release_Notes.html".format(base_name, family.upper())
+        # only read the release notes, we don't care about the rest
+        html = zip_ref.read(release_note_path).decode("utf-8", errors="replace")
+        header_remote_version[family] = get_header_version(html)
+    if not header_remote_version[family]:
+        print("No version match in remote release notes for", family)
+        exit(1)
+
 update_required = False
-for family in sorted(cube_urls):
-    current, new = cube_current_versions[family], cube_new_versions[family]
-    print("{}: v{} -> v{}\t{}".format(family, current, new, "update!" if current != new else "ok"))
-    if current != new:
+# intermediate report on cube versions
+for family in stm32_families:
+    status = "{}: Cube   v{} -> v{}\t{}"
+    print(status.format(family.upper(), cube_local_version[family], cube_remote_version[family],
+            "update!" if family in check_header_version else "ok"))
+print()
+# final report
+for family in check_header_version:
+    status = "{}: Header v{} -> v{}\t{}"
+    hl = header_local_version[family]
+    hr = header_remote_version[family]
+    print(status.format(family.upper(), hl, hr, "update!" if hl != hr else "ok"))
+    if hl != hr:
         update_required = True
 
 # if an update is required, fail this "test"


### PR DESCRIPTION
This change not only compares the local and remote cube versions, which can lead to false positives, but also downloads the new cube files and checks the remote header version.